### PR TITLE
include force_v4 argument with default TRUE in all functions

### DIFF
--- a/R/adp.R
+++ b/R/adp.R
@@ -43,10 +43,10 @@
 #'
 #' @family things related to adp data
 #'
-#' @author Dan Kelley
+#' @author Dan Kelley and Clark Richards
 #'
 #' @export
-adp2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
+adp2ncdf <- function(x, varTable=NULL, ncfile=NULL, force_v4=TRUE, debug=0)
 {
     dmsg(debug, "adp2ncdf(..., ncfile=\"", ncfile, "\") {\n")
     if (!inherits(x, "adp"))
@@ -106,7 +106,7 @@ adp2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
             vars[[item]] <- ncvar_def(item, units="", dim=time)
         }
     }
-    nc <- nc_create(ncfile, vars)
+    nc <- nc_create(ncfile, vars, force_v4=force_v4)
     dmsg(debug, "  Storing time and distance\n")
     dmsg(debug, "    time\n")
     ncvar_put(nc, "time", as.numeric(x@data$time))

--- a/R/adv.R
+++ b/R/adv.R
@@ -33,10 +33,10 @@
 #'
 #' @family things related to adv data
 #'
-#' @author Dan Kelley
+#' @author Dan Kelley and Clark Richards
 #'
 #' @export
-adv2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
+adv2ncdf <- function(x, varTable=NULL, ncfile=NULL, force_v4=TRUE, debug=0)
 {
     dmsg(debug, "adv2ncdf(..., ncfile=\"", ncfile, "\") {\n")
     if (!inherits(x, "adv"))
@@ -117,7 +117,7 @@ adv2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
             }
         }
     }
-    nc <- nc_create(ncfile, vars)
+    nc <- nc_create(ncfile, vars, force_v4=force_v4)
     dmsg(debug, "  Storing data:\n")
     for (name in dataNames) {
         item <- x@data[[name]]

--- a/R/ctd.R
+++ b/R/ctd.R
@@ -49,10 +49,10 @@
 #'
 #' @family things related to CTD data
 #'
-#' @author Dan Kelley
+#' @author Dan Kelley and Clark Richards
 #'
 #' @export
-ctd2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
+ctd2ncdf <- function(x, varTable=NULL, ncfile=NULL, force_v4=TRUE, debug=0)
 {
     dmsg(debug, "ctd2ncdf(..., ncfile=\"", ncfile, "\") {\n")
     if (!inherits(x, "ctd"))
@@ -131,7 +131,7 @@ ctd2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
         standardNames[["latitude"]] <- "latitude"
         dmsg(debug, "      latitude\n")
     }
-    nc <- nc_create(ncfile, vars)
+    nc <- nc_create(ncfile, vars, force_v4=force_v4)
     dmsg(debug, "  Storing data.\n")
     for (name in names(x@data)) {
         dmsg(debug, "    ", name, " (", NLEVEL, " values)\n")

--- a/R/oce2ncdf.R
+++ b/R/oce2ncdf.R
@@ -13,6 +13,12 @@
 #' for a file name to be created automatically (e.g. `ctd.nc` for
 #' a CTD object).
 #'
+#' @param force_v4 logical value which controls the netCDF file version during
+#' the \link[ncdf4]{nc_create} step. The default here is TRUE, whereas the
+#' \link[ncdf4]{ncdf4-package} defaults to FALSE (ensuring that the netCDF
+#' file is compatible with netCDF v3). Some features, including large data
+#' sizes, may require v4.
+#' 
 #' @param debug integer, 0 (the default) for quiet action apart
 #' from messages and warnings, or any larger value to see more
 #' output that describes the processing steps.
@@ -23,18 +29,18 @@
 #' @importFrom utils str
 ## @importFrom yaml yaml.load_file
 #'
-#' @author Dan Kelley
+#' @author Dan Kelley and Clark Richards
 #'
 #' @export
-oce2ncdf <- function(x, varTable=NULL, ncfile=NULL, debug=0)
+oce2ncdf <- function(x, varTable=NULL, ncfile=NULL, force_v4=TRUE, debug=0)
 {
     if (!inherits(x, "oce"))
         stop("'x' must be an oce object")
     xclass <- as.character(class(x))
     switch(xclass,
-        ctd=ctd2ncdf(x, varTable=varTable, ncfile=ncfile, debug=debug),
-        adp=adp2ncdf(x, varTable=varTable, ncfile=ncfile, debug=debug),
-        adv=adv2ncdf(x, varTable=varTable, ncfile=ncfile, debug=debug),
+        ctd=ctd2ncdf(x, varTable=varTable, ncfile=ncfile, force_v4=force_v4, debug=debug),
+        adp=adp2ncdf(x, varTable=varTable, ncfile=ncfile, force_v4=force_v4, debug=debug),
+        adv=adv2ncdf(x, varTable=varTable, ncfile=ncfile, force_v4=force_v4, debug=debug),
         stop("oce2ncdf() cannot handle \"", xclass, "\" objects")
     )
 }

--- a/man/adp2ncdf.Rd
+++ b/man/adp2ncdf.Rd
@@ -4,7 +4,7 @@
 \alias{adp2ncdf}
 \title{Save an adp object to a netcdf file}
 \usage{
-adp2ncdf(x, varTable = NULL, ncfile = NULL, debug = 0)
+adp2ncdf(x, varTable = NULL, ncfile = NULL, force_v4 = TRUE, debug = 0)
 }
 \arguments{
 \item{x}{an oce object of class \code{adp}, as created by e.g. \code{\link[oce:read.adp]{oce::read.adp()}}.}
@@ -16,6 +16,12 @@ up variable names, units, etc.}
 \item{ncfile}{character value naming the output file.  Use NULL
 for a file name to be created automatically (e.g. \code{ctd.nc} for
 a CTD object).}
+
+\item{force_v4}{logical value which controls the netCDF file version during
+the \link[ncdf4]{nc_create} step. The default here is TRUE, whereas the
+\link[ncdf4]{ncdf4-package} defaults to FALSE (ensuring that the netCDF
+file is compatible with netCDF v3). Some features, including large data
+sizes, may require v4.}
 
 \item{debug}{integer, 0 (the default) for quiet action apart
 from messages and warnings, or any larger value to see more
@@ -66,6 +72,6 @@ Other things related to adp data:
 \code{\link{ncdf2adp}()}
 }
 \author{
-Dan Kelley
+Dan Kelley and Clark Richards
 }
 \concept{things related to adp data}

--- a/man/adv2ncdf.Rd
+++ b/man/adv2ncdf.Rd
@@ -4,7 +4,7 @@
 \alias{adv2ncdf}
 \title{Save an adv object to a netcdf file}
 \usage{
-adv2ncdf(x, varTable = NULL, ncfile = NULL, debug = 0)
+adv2ncdf(x, varTable = NULL, ncfile = NULL, force_v4 = TRUE, debug = 0)
 }
 \arguments{
 \item{x}{an oce object of class \code{adv}, as created by e.g. \code{\link[oce:read.adv]{oce::read.adv()}}.}
@@ -16,6 +16,12 @@ up variable names, units, etc.}
 \item{ncfile}{character value naming the output file.  Use NULL
 for a file name to be created automatically (e.g. \code{ctd.nc} for
 a CTD object).}
+
+\item{force_v4}{logical value which controls the netCDF file version during
+the \link[ncdf4]{nc_create} step. The default here is TRUE, whereas the
+\link[ncdf4]{ncdf4-package} defaults to FALSE (ensuring that the netCDF
+file is compatible with netCDF v3). Some features, including large data
+sizes, may require v4.}
 
 \item{debug}{integer, 0 (the default) for quiet action apart
 from messages and warnings, or any larger value to see more
@@ -56,6 +62,6 @@ Other things related to adv data:
 \code{\link{ncdf2adv}()}
 }
 \author{
-Dan Kelley
+Dan Kelley and Clark Richards
 }
 \concept{things related to adv data}

--- a/man/ctd2ncdf.Rd
+++ b/man/ctd2ncdf.Rd
@@ -4,7 +4,7 @@
 \alias{ctd2ncdf}
 \title{Save a ctd object to a netcdf file}
 \usage{
-ctd2ncdf(x, varTable = NULL, ncfile = NULL, debug = 0)
+ctd2ncdf(x, varTable = NULL, ncfile = NULL, force_v4 = TRUE, debug = 0)
 }
 \arguments{
 \item{x}{an oce object of class \code{ctd}, as created by e.g. \code{\link[oce:as.ctd]{oce::as.ctd()}}
@@ -17,6 +17,12 @@ up variable names, units, etc.}
 \item{ncfile}{character value naming the output file.  Use NULL
 for a file name to be created automatically (e.g. \code{ctd.nc} for
 a CTD object).}
+
+\item{force_v4}{logical value which controls the netCDF file version during
+the \link[ncdf4]{nc_create} step. The default here is TRUE, whereas the
+\link[ncdf4]{ncdf4-package} defaults to FALSE (ensuring that the netCDF
+file is compatible with netCDF v3). Some features, including large data
+sizes, may require v4.}
 
 \item{debug}{integer, 0 (the default) for quiet action apart
 from messages and warnings, or any larger value to see more
@@ -71,6 +77,6 @@ Other things related to CTD data:
 \code{\link{ncdf2ctd}()}
 }
 \author{
-Dan Kelley
+Dan Kelley and Clark Richards
 }
 \concept{things related to CTD data}

--- a/man/oce2ncdf.Rd
+++ b/man/oce2ncdf.Rd
@@ -4,7 +4,7 @@
 \alias{oce2ncdf}
 \title{Save an oce-class object as a netcdf file.}
 \usage{
-oce2ncdf(x, varTable = NULL, ncfile = NULL, debug = 0)
+oce2ncdf(x, varTable = NULL, ncfile = NULL, force_v4 = TRUE, debug = 0)
 }
 \arguments{
 \item{x}{an oce-class object. The subclass of this object determines
@@ -19,6 +19,12 @@ up variable names, units, etc.}
 for a file name to be created automatically (e.g. \code{ctd.nc} for
 a CTD object).}
 
+\item{force_v4}{logical value which controls the netCDF file version during
+the \link[ncdf4]{nc_create} step. The default here is TRUE, whereas the
+\link[ncdf4]{ncdf4-package} defaults to FALSE (ensuring that the netCDF
+file is compatible with netCDF v3). Some features, including large data
+sizes, may require v4.}
+
 \item{debug}{integer, 0 (the default) for quiet action apart
 from messages and warnings, or any larger value to see more
 output that describes the processing steps.}
@@ -28,5 +34,5 @@ output that describes the processing steps.}
 and then dispatching to an internal function, as appropriate.
 }
 \author{
-Dan Kelley
+Dan Kelley and Clark Richards
 }


### PR DESCRIPTION
This PR arose from a recent issue noted by @kurtisanstey where the netCDF file creation fails if the variables are "too big" (I put this in quotes because I don't actually know what the limit is). This appears to be a limitation of the netCDF v3 file, which is what `ncdf4::nc_create()` defaults to, by way of the `force_v4=FALSE` argument.

All I've done here is to add the `force_v4` argument to `oce2ncdf()` (and each of the sub-functions, e.g. `adp2ncdf()`), but with a default value of `TRUE`. Considering netCDF v4 was released in 2008, I think we're safe to assume that most people creating new nc files are fine with using version 4.